### PR TITLE
Publish 0.5.4 string cache codegen

### DIFF
--- a/string-cache-codegen/Cargo.toml
+++ b/string-cache-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string_cache_codegen"
-version = "0.5.3"  # Also update ../README.md when making a semver-breaking change
+version = "0.5.4"  # Also update ../README.md when making a semver-breaking change
 authors = [ "The Servo Project Developers" ]
 description = "A codegen library for string-cache, developed as part of the Servo project."
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Publishes changes in revision d9e888f2f61d43c1868849a506104ee02d79027c needed for https://github.com/servo/html5ever/issues/573

Changes are SemVer patch increase. 

Hyrum's versioning might differ if something depended on random iteration order.